### PR TITLE
fix: remove noUnusedLocals and noUnusedParameters rules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,8 @@
     "lib": [
       "es2017"
     ],
-    "noUnusedLocals": true,
     "skipLibCheck": true,
     "incremental": true,
-    "noUnusedParameters": true,
     "removeComments": true,
     "declaration": false,
     "moduleResolution": "node",


### PR DESCRIPTION
Those can be checked with a linter and they add unnecessary TypeScript errors
during development.