### PR TITLE
feat: target ES2019 and enable ES2020 features

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "ES2019",
     "module": "commonjs",
     "lib": [
-      "es2017"
+      "ES2019",
+      "ES2020.BigInt",
+      "ES2020.Promise",
+      "ES2020.String",
+      "ES2020.Symbol.WellKnown"
     ],
     "noUnusedLocals": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Adonis requires at least Node.js 12. That version fully supports ES2019
and has support for some ES2020 library features.