### PR TITLE
Remove relative baseUrl, rootDir and outDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,14 +12,11 @@
     "removeComments": true,
     "declaration": false,
     "moduleResolution": "node",
-    "outDir": "../../build",
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "esModuleInterop": true,
-    "rootDir": "../../",
-    "baseUrl": "../../"
+    "esModuleInterop": true
   },
   "include": [
     "**/*"


### PR DESCRIPTION
For the following reason:
1. These relative path breaks in pnpm
2. Project template has already defined them in tsconfig.json, so no need to include them in preset

Fix #12